### PR TITLE
Update nominal_clauses.json

### DIFF
--- a/configs/arethusa.harrington/harrington_labels/nominal_clauses.json
+++ b/configs/arethusa.harrington/harrington_labels/nominal_clauses.json
@@ -1,6 +1,6 @@
 {
   "nested" : {
-    "INDCMND" : {
+    "SUBST" : {
       "short" : "NOM-INDCMND",
       "long" : "indirect command"
     },
@@ -15,6 +15,10 @@
     "INDSTAT" : {
       "short" : "NOM-INDSTAT",
       "long" : "indirect statement"
+    },
+    "DIRSTAT" : {
+      "short" : "NOM-DIRSTAT",
+      "long" : "direct statement"
     }
   }
 }


### PR DESCRIPTION
added DIRSTAT tag for direct statement (usually as OBJ) with verbs like incite; changed INDCOMND to clearer SUBST
