### PR TITLE
Update nominal_clauses.json

### DIFF
--- a/configs/arethusa.harrington/harrington_labels/nominal_clauses.json
+++ b/configs/arethusa.harrington/harrington_labels/nominal_clauses.json
@@ -1,8 +1,8 @@
 {
   "nested" : {
-    "INDCMND" : {
-      "short" : "NOM-INDCMND",
-      "long" : "indirect command"
+    "SUBST" : {
+      "short" : "NOM-SUBST",
+      "long" : "substantive noun clause"
     },
     "FEARCL" : {
       "short" : "NOM-FEARCL",
@@ -15,6 +15,10 @@
     "INDSTAT" : {
       "short" : "NOM-INDSTAT",
       "long" : "indirect statement"
+    }
+    "DIRSTAT" : {
+      "short" : "NOM-DIRSTAT",
+      "long" : "direct statement"
     }
   }
 }


### PR DESCRIPTION
added DIRSTAT tag for use with very such as inquit (usually as OBJ); changed INDCMND tag to SUBST for clarity across all potential uses
