### PR TITLE
Changes @rgorman's tag set so C_Cl doesn't not break Arethusa.

### DIFF
--- a/configs/arethusa.relation/elmlatch3.json
+++ b/configs/arethusa.relation/elmlatch3.json
@@ -12,14 +12,10 @@
             "short": "Atr",
             "long": "attribute"
         },
-        
         "Adv": {
             "short": "Adv",
             "long": "adverbial"
         },
-        
-        
-        
         "Pnom": {
             "short": "Pnom",
             "long": "predicate nom"
@@ -52,14 +48,10 @@
             "short": "Mns",
             "long": "means"
         },
-        
         "Mnr": {
             "short": "Mnr",
             "long": "manner"
         },
-        
-        
-        
         "Acmp": {
             "short": "Acmp",
             "long": "accompaniment"
@@ -68,8 +60,8 @@
             "short": "Sepr",
             "long": "separation"
         },
-        "C_Cl": {
-            "short": "C_Cl",
+        "CmplCl": {
+            "short": "CmplCl",
             "long": "complement cl"
         },
         "APOS": {

--- a/configs/arethusa.relation/elmlatch4.json
+++ b/configs/arethusa.relation/elmlatch4.json
@@ -64,8 +64,8 @@
             "short": "Rsp",
             "long": "respect"
         },
-        "C_Cl": {
-            "short": "C_Cl",
+        "CmplCl": {
+            "short": "CmplCl",
             "long": "complement cl"
         },
         "APOS": {


### PR DESCRIPTION
Underscore in current tag set causes unexpected behavior in Aerthusa. This commit contains adjustment of the offending tags in arethusa-configs/configs/arethusa.relation/elmlatch3.json and elmlatch4.json.