### PR TITLE
correction to wheelock tag set. Adds MnVb.

### DIFF
--- a/configs/arethusa.relation/wheelock1-3.json
+++ b/configs/arethusa.relation/wheelock1-3.json
@@ -1,6 +1,10 @@
 {
   "relations": {
     "labels": {
+      "MnVb": {
+        "short": "MnVb",
+        "long": "main verb"
+      },
       "Sbj": {
         "short": "Sbj",
         "long": "subject"


### PR DESCRIPTION
Fixes omission of 'main verb' tag for relationship tag set.  Wheelock chapters 1-3.