### PR TITLE
Add Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arethusa-client (0.1.17)
+      nokogiri
+      thor
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    rake (12.3.3)
+    thor (0.20.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  arethusa-client
+  nokogiri (= 1.6.7.2)
+  rake
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
According to the [Bundler documentation](https://bundler.io/v1.3/rationale.html), the `Gemfile.lock` file should be checked in to source control:

> After developing your application for a while, check in the application together with the Gemfile and Gemfile.lock snapshot.