### PR TITLE
Update dependencies and Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
   - 2.6.0
 script:
   - bundle exec rake build
+  - bundle exec bundler-audit check --update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-- "2.0"
+  - 2.6.0
 script:
- - bundle exec rake build
+  - bundle exec rake build

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.6.0'
+
 gem 'rake'
 gem 'arethusa-client'
 gem 'nokogiri','1.6.7.2'

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ ruby '2.6.0'
 gem 'rake'
 gem 'arethusa-client'
 gem 'nokogiri','1.6.7.2'
+
+group :development, :test do
+  gem 'bundler-audit'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.6.0'
 
 gem 'rake'
 gem 'arethusa-client'
-gem 'nokogiri','1.6.7.2'
+gem 'nokogiri'
 
 group :development, :test do
   gem 'bundler-audit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,5 +18,8 @@ DEPENDENCIES
   nokogiri (= 1.6.7.2)
   rake
 
+RUBY VERSION
+   ruby 2.6.0p0
+
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,9 @@ GEM
     arethusa-client (0.1.17)
       nokogiri
       thor
+    bundler-audit (0.6.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 0.18)
     mini_portile2 (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -15,6 +18,7 @@ PLATFORMS
 
 DEPENDENCIES
   arethusa-client
+  bundler-audit
   nokogiri (= 1.6.7.2)
   rake
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GEM
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
-    mini_portile2 (2.0.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
-    rake (12.3.3)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.5)
+      mini_portile2 (~> 2.4.0)
+    rake (13.0.0)
     thor (0.20.3)
 
 PLATFORMS
@@ -19,7 +19,7 @@ PLATFORMS
 DEPENDENCIES
   arethusa-client
   bundler-audit
-  nokogiri (= 1.6.7.2)
+  nokogiri
   rake
 
 RUBY VERSION


### PR DESCRIPTION
This PR is comes out of the discussion in https://github.com/alpheios-project/arethusa-configs/pull/75

It has three parts:

* Update Ruby version
* Add `bundler-audit` (so we don't need to wait for dependabot's PRs to find a vulnerability)
* Update dependencies (solving the original issue)